### PR TITLE
fix 500 internal error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 certifi==2022.12.7
 charset-normalizer==3.1.0
-click==8.1.3
+click>=8.1.3
 duckduckgo-search>=3.9.9
 Flask==2.2.3
 gunicorn==20.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 certifi==2022.12.7
 charset-normalizer==3.1.0
 click==8.1.3
-duckduckgo-search>=3.8.5
+duckduckgo-search>=3.9.9
 Flask==2.2.3
 gunicorn==20.1.0
 idna==3.4


### PR DESCRIPTION
The original reverse is not available due to a change in the duckduckgo interface.
The change to this pr is to update the ddg dependency version: 3.9.9 (https://pypi.org/project/duckduckgo-search)

（今天git下来无意间看到的 我刚准备逆向 更新了一下上游就好了😅）
